### PR TITLE
Remove robot_pose_ekf from launch files

### DIFF
--- a/husky_gazebo/launch/husky_empty_world.launch
+++ b/husky_gazebo/launch/husky_empty_world.launch
@@ -39,14 +39,4 @@ robot model in Gazebo
   <include file="$(find gazebo_ros)/launch/empty_world.launch">
     <arg name="use_sim_time" value="true"/>
   </include>
-  <node pkg="robot_pose_ekf" type="robot_pose_ekf" name="robot_pose_ekf">
-    <rosparam>
-      freq: 10.0
-      sensor_timeout: 1.0
-      publish_tf: true
-      odom_used: true
-      vo_used: true
-      output_frame: odom
-    </rosparam>
-  </node>
 </launch>

--- a/husky_gazebo/launch/husky_playpen.launch
+++ b/husky_gazebo/launch/husky_playpen.launch
@@ -45,16 +45,4 @@ robot model in Gazebo
     <arg name="headless" value="false"/>
     <arg name="debug" value="false"/>
   </include>
-
-
-  <!--node pkg="robot_pose_ekf" type="robot_pose_ekf" name="robot_pose_ekf">
-    <rosparam>
-      freq: 10.0
-      sensor_timeout: 1.0
-      publish_tf: true
-      odom_used: true
-      vo_used: true
-      output_frame: odom
-    </rosparam>
-  </node-->
 </launch>


### PR DESCRIPTION
Remove launching robot_pose_ekf from the simulation launch files to eliminate any confusion. Due to the changes to the TF tree (removal of base_footprint) this node no longer functions with this setup.

In the future this will be replaced by the use of robot_localization node.
